### PR TITLE
update deploy

### DIFF
--- a/Emmet.xcodeproj/project.pbxproj
+++ b/Emmet.xcodeproj/project.pbxproj
@@ -1182,7 +1182,7 @@
 				HEADER_SEARCH_PATHS = "$(ESPRESSO_PATH)/Contents/Headers";
 				INFOPLIST_FILE = EspressoPlugin/Info.plist;
 				INSTALL_PATH = /;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = Emmet;
 				WRAPPER_EXTENSION = sugar;
 			};
@@ -1208,7 +1208,7 @@
 				HEADER_SEARCH_PATHS = "$(ESPRESSO_PATH)/Contents/Headers";
 				INFOPLIST_FILE = EspressoPlugin/Info.plist;
 				INSTALL_PATH = /;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = Emmet;
 				WRAPPER_EXTENSION = sugar;
 			};
@@ -1229,7 +1229,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				INFOPLIST_FILE = "CodaPlugin/CodaPlugin-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = Emmet;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = codaplugin;
@@ -1251,7 +1251,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				INFOPLIST_FILE = "CodaPlugin/CodaPlugin-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = Emmet;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = codaplugin;
@@ -1299,7 +1299,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-lffi";
 				SDKROOT = macosx;
@@ -1326,7 +1326,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-lffi";
 				SDKROOT = macosx;
@@ -1351,7 +1351,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				INFOPLIST_FILE = "TextMatePlugin/TextMatePlugin-Info.plist";
 				INSTALL_PATH = /;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = Emmet;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = tmplugin;
@@ -1375,7 +1375,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				INFOPLIST_FILE = "TextMatePlugin/TextMatePlugin-Info.plist";
 				INSTALL_PATH = /;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = Emmet;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = tmplugin;
@@ -1396,7 +1396,7 @@
 				HEADER_SEARCH_PATHS = "${SRCROOT}/**";
 				INFOPLIST_FILE = "ZenCodingSample/EmmetSample-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = EmmetSample;
 				WRAPPER_EXTENSION = app;
 			};
@@ -1416,7 +1416,7 @@
 				HEADER_SEARCH_PATHS = "${SRCROOT}/**";
 				INFOPLIST_FILE = "ZenCodingSample/EmmetSample-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = EmmetSample;
 				WRAPPER_EXTENSION = app;
 			};
@@ -1434,7 +1434,7 @@
 				GCC_PREFIX_HEADER = "ZenCoding/Emmet-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "ZenCoding/Emmet-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = Emmet;
 				WRAPPER_EXTENSION = framework;
 			};
@@ -1452,7 +1452,7 @@
 				GCC_PREFIX_HEADER = "ZenCoding/Emmet-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "ZenCoding/Emmet-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = Emmet;
 				WRAPPER_EXTENSION = framework;
 			};

--- a/TextMatePlugin/TextMatePlugin-Info.plist
+++ b/TextMatePlugin/TextMatePlugin-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string>logo.tiff</string>
 	<key>CFBundleIdentifier</key>
-	<string>io.emmet.EmmetTextmate</string>
+	<string>io.emmet.EmmetTM2</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
TextMate beta2.11 fights against the installation of the plugin by explicitly checking the bundle identifier.

I've been able to get it working again by downloading @pingjiang's branch and changing the identifier to something that doesn't include "io.emmet.EmmetTextmate"; "io.emmet.EmmetTM2".

This is now installing and working on my machine.
